### PR TITLE
fix: fixes pdf-parse issue with ESM

### DIFF
--- a/officeParser.js
+++ b/officeParser.js
@@ -4,7 +4,7 @@ const decompress    = require('decompress');
 const fs            = require('fs');
 const rimraf        = require('rimraf');
 const fileType      = require('file-type');
-const pdfParse      = require('pdf-parse/lib/pdf-parse');
+const pdfParse      = require('pdf-parse/lib/pdf-parse'); // https://gitlab.com/autokent/pdf-parse/-/issues/24
 const { DOMParser } = require('@xmldom/xmldom');
 
 /** Header for error messages */

--- a/officeParser.js
+++ b/officeParser.js
@@ -4,7 +4,7 @@ const decompress    = require('decompress');
 const fs            = require('fs');
 const rimraf        = require('rimraf');
 const fileType      = require('file-type');
-const pdfParse      = require('pdf-parse');
+const pdfParse      = require('pdf-parse/lib/pdf-parse');
 const { DOMParser } = require('@xmldom/xmldom');
 
 /** Header for error messages */
@@ -584,7 +584,7 @@ let globalFileNameIterator = 0;
  * to allow the files to be sorted in chronological order
  * @param {string} tempFilesLocation Directory whether this new file needs to be stored
  * @param {string} ext               File extension for this new generated file name
- * @returns {string} 
+ * @returns {string}
  */
 function getNewFileName(tempFilesLocation, ext) {
     // Get the iterator part of the file name

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "officeparser",
-  "version": "4.0.0",
+  "version": "4.0.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "officeparser",
-      "version": "4.0.0",
+      "version": "4.0.8",
       "license": "MIT",
       "dependencies": {
         "@xmldom/xmldom": "^0.8.10",

--- a/test/testOfficeParser.js
+++ b/test/testOfficeParser.js
@@ -49,7 +49,7 @@ const localSupportedExtensionsList = supportedExtensionTests.map(test => test.ex
 
 /** Get filename for an extension */
 function getFilename(ext, isContentFile = false) {
-    return `test/files/test.${ext}` + (isContentFile ? `.txt` : '');
+    return `../test/files/test.${ext}` + (isContentFile ? `.txt` : '');
 }
 
 /** Run test for a passed extension */


### PR DESCRIPTION
pdf-parse is old and unmaintained, theres a known issue with ESM https://gitlab.com/autokent/pdf-parse/-/issues/24

This adds the recommended workaround. Also fixes a path issue in the tester file.