### PR TITLE
feat: bump decompress version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@xmldom/xmldom": "^0.8.10",
-        "decompress": "^4.2.0",
+        "decompress": "^4.2.1",
         "file-type": "^16.5.4",
         "node-ensure": "^0.0.0",
         "rimraf": "^2.6.3"

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "homepage": "https://github.com/harshankur/officeParser#readme",
   "dependencies": {
     "@xmldom/xmldom": "^0.8.10",
-    "decompress": "^4.2.0",
+    "decompress": "^4.2.1",
     "file-type": "^16.5.4",
     "node-ensure": "^0.0.0",
     "rimraf": "^2.6.3"


### PR DESCRIPTION
* Bumps "decompress" package version. Versions < 4.2.1 are subject to an [Arbitrary File Write ](https://security.snyk.io/vuln/SNYK-JS-DECOMPRESSTAR-559095?_gl=1%2a1x00ajk%2a_ga%2aOTUzMjMwNDI1LjE3MTkyNjE5MzA.%2a_ga_X9SH3KP7B4%2aMTcxOTUwNjM5Mi40LjEuMTcxOTUwOTA1NS4wLjAuMA..) exploit.

* The security issue with decompress package should in theory be [resolved with 4.2.1](https://github.com/advisories/GHSA-qgfr-5hqp-vrw9), and was resolved in the following PR: https://github.com/kevva/decompress/pull/73.

Without this version update, any packages consuming officeParser will surface a vulnerability warning (such as when running sec tools like Snyk) about decompress.