### PR TITLE
fix(types): propagate destination generic to ConversionResult return

### DIFF
--- a/src/OfficeConverter.ts
+++ b/src/OfficeConverter.ts
@@ -50,12 +50,13 @@ export class OfficeConverter {
      */
     public static async convert<
         F extends string | Buffer | ArrayBuffer | Uint8Array,
-        T extends SupportedFileType = InferFileTypeFromPath<F>
+        T extends SupportedFileType = InferFileTypeFromPath<F>,
+        D extends SupportedDestination<T> = SupportedDestination<T>
     >(
         file: F,
-        destination: SupportedDestination<T>,
-        config?: OfficeConverterConfig<SupportedDestination<T>, T>
-    ): Promise<ConversionResult<SupportedDestination<T>>> {
+        destination: D,
+        config?: OfficeConverterConfig<D, T>
+    ): Promise<ConversionResult<D>> {
         // 1. Prepare Parser Configuration
         // We prioritize the top-level onWarning if provided.
         const parserConfig: OfficeParserConfig = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1666,6 +1666,6 @@ export interface OfficeParserAST {
         this: T,
         destination: D,
         config?: GeneratorConfig<D>
-    ): Promise<ConversionResult>;
+    ): Promise<ConversionResult<D>>;
 }
 

--- a/src/utils/astUtils.ts
+++ b/src/utils/astUtils.ts
@@ -35,8 +35,8 @@ export function createAST(
             this: T,
             destination: D,
             genConfig?: GeneratorConfig<D>
-        ): Promise<ConversionResult> {
-            return OfficeGenerator.generate(this as any, destination, genConfig) as Promise<ConversionResult>;
+        ): Promise<ConversionResult<D>> {
+            return OfficeGenerator.generate(this as any, destination, genConfig) as Promise<ConversionResult<D>>;
         }
     };
 }


### PR DESCRIPTION
## Summary

`OfficeParserAST.to()` and `OfficeConverter.convert()` both declare their return as `Promise<ConversionResult>` (so `D` defaults to the full `UniversalGeneratorFormat` union) instead of `Promise<ConversionResult<D>>`. The result: callers passing a literal destination like `"md"` or `"pdf"` can't narrow `.value` from the full union (`string | Uint8Array | OfficeChunk[]`) to the specific type the runtime conditional already guarantees.

This PR threads the destination generic into the return type so the conditional in `ConversionResult.value` actually flows from the destination argument.

## Changes

- `types.ts`: `OfficeParserAST.to<D>(...): Promise<ConversionResult>` → `Promise<ConversionResult<D>>`.
- `utils/astUtils.ts`: matching implementation return type.
- `OfficeConverter.ts`: add an explicit `D extends SupportedDestination<T>` generic so the destination literal carries through to `ConversionResult<D>` and `OfficeConverterConfig<D, T>`.

No runtime behavior change — the conditional in `ConversionResult.value` already produced the right runtime type per destination; this just lets TypeScript see it.

## Verification

```ts
import { OfficeConverter, parseOffice } from "officeparser";

const buf = new Uint8Array(1);

// Before this PR: r1.value is `string | Uint8Array | OfficeChunk[]`
// After:          r1.value is `string`
const r1 = await OfficeConverter.convert(buf, "md");
const md: string = r1.value;

const ast = await parseOffice(buf);
const r2 = await ast.to("md");
const md2: string = r2.value;

const r3 = await ast.to("pdf");
const pdf: Uint8Array = r3.value;

const r4 = await ast.to("chunks");
const chunks: OfficeChunk[] = r4.value;
```

Build (`npm run build:node`) passes locally.

## Motivation

Hit this in a production worker where we extract markdown from uploaded proposals. The workaround we ship today is a runtime `typeof value !== "string"` guard purely to satisfy the type system; the guard can never fire at runtime because the library's own conditional type guarantees `string` for `"md"`. Once this PR ships we drop that guard and let TypeScript reflect the runtime contract.